### PR TITLE
Increased grace period for dcos-scale health check.

### DIFF
--- a/repo/packages/S/scale/1/marathon.json.mustache
+++ b/repo/packages/S/scale/1/marathon.json.mustache
@@ -15,7 +15,7 @@
         "path": "/",
         "protocol": "HTTP",
         "portIndex": 0,
-        "gracePeriodSeconds": 300,
+        "gracePeriodSeconds": 600,
         "intervalSeconds": 30,
         "timeoutSeconds": 20,
         "maxConsecutiveFailures": 3,


### PR DESCRIPTION
it takes too long to docker pull both scale and scale-db and marathon marks the app as unhealthy before it has booted up.
