### PR TITLE
Added default persistent storage path for scale-db

### DIFF
--- a/repo/packages/S/scale/1/config.json
+++ b/repo/packages/S/scale/1/config.json
@@ -90,7 +90,7 @@
         "db-host-vol": {
           "type": "string",
           "description": "Path to persistent storage",
-          "default": ""
+          "default": "/shared/dcos-scale-db"
         },
         "vhost-name": {
           "type": "string",

--- a/repo/packages/S/scale/1/marathon.json.mustache
+++ b/repo/packages/S/scale/1/marathon.json.mustache
@@ -12,10 +12,10 @@
         }
     },
     "healthChecks": [{
-        "path": "/",
+        "path": "/ui/api/status/",
         "protocol": "HTTP",
         "portIndex": 0,
-        "gracePeriodSeconds": 300,
+        "gracePeriodSeconds": 600,
         "intervalSeconds": 30,
         "timeoutSeconds": 20,
         "maxConsecutiveFailures": 3,


### PR DESCRIPTION
This should place the persistent storage under the NFS share that Jonathan created, by default. If that storage isn't there it will auto create the folders.
